### PR TITLE
RepositoryDetailFragamentから戻った時、検索結果が残るように変更

### DIFF
--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchRepositoryFragment.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchRepositoryFragment.kt
@@ -27,12 +27,12 @@ class SearchRepositoryFragment : Fragment(R.layout.search_repository_fragment) {
     private var _binding: SearchRepositoryFragmentBinding? = null
     private val binding get() = _binding!!
 
+    private val viewModel = SearchRepositoryViewModel()
+
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
 
         _binding = SearchRepositoryFragmentBinding.bind(view)
-
-        val viewModel = SearchRepositoryViewModel()
 
         val layoutManager = LinearLayoutManager(requireContext())
         val dividerItemDecoration =
@@ -58,13 +58,16 @@ class SearchRepositoryFragment : Fragment(R.layout.search_repository_fragment) {
                             ).show()
                         }
                     ) {
-                        viewModel.searchResults(it).apply { adapter.submitList(this) }
+                        viewModel.searchResults(it)
+                        adapter.submitList(viewModel.repositoryList)
                     }
                 }
                 return@setOnEditorActionListener true
             }
             return@setOnEditorActionListener false
         }
+
+        adapter.submitList(viewModel.repositoryList)
 
         binding.recyclerView.also {
             it.layoutManager = layoutManager

--- a/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchRepositoryViewModel.kt
+++ b/app/src/main/kotlin/jp/co/yumemi/android/code_check/ui/search/SearchRepositoryViewModel.kt
@@ -20,13 +20,17 @@ import org.json.JSONObject
  * @see SearchRepositoryFragment
  * */
 class SearchRepositoryViewModel : ViewModel() {
+
+    private var _repositoryList: List<RepositoryInfo>? = null
+    val repositoryList get() = _repositoryList
+
     // 検索結果
     // TODO: エラーハンドリングを追加する
     /**
      * GitHubのAPIを使ってリポジトリを検索する関数
      * @param inputText 検索キーワード
      * */
-    suspend fun searchResults(inputText: String): List<RepositoryInfo> =
+    suspend fun searchResults(inputText: String): Unit =
         withContext(Dispatchers.IO) {
             val client = HttpClient(Android)
             async {
@@ -68,7 +72,7 @@ class SearchRepositoryViewModel : ViewModel() {
 
                 lastSearchDate = Date()
 
-                return@async items.toList()
+                _repositoryList = items.toList()
             }.await()
         }
 }


### PR DESCRIPTION
## 概要
<!-- なにをやったかを書く -->
RepositoryDetailFragamentから戻った時、検索結果が残るように変更
驚き最小の法則
## 変更点
<!-- 変更した箇所を書く -->
- ViewModelで検索結果を保持するように変更
- FragmentがViewModelをクラスのメンバとして持つように変更

## issues
<!-- issueのリンクを書く -->
- #5

## 影響範囲
<!-- 変更によるり他へ影響があれば書く -->
なし

## 参考文献など
<!-- 参考文献などあれば書く -->
なし

## 動作条件
<!-- 動作条件を書く　バージョンなど -->
- IDE：Android Studio Arctic Fox | 2020.3.1 Patch 1
- Kotlin：1.5.31
- Java：11
- Gradle：7.0.1
- minSdk：23
- targetSdk：31


<!-- GitHubのDevelopmentにissueをリンクさせる -->